### PR TITLE
task: profiling

### DIFF
--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell.spec.ts
@@ -19,7 +19,7 @@ import { PortfolioSnapshotServiceMock } from '@ghostfolio/api/services/queues/po
 import { parseDate } from '@ghostfolio/common/helper';
 
 import { Big } from 'big.js';
-import { last } from 'lodash';
+import { last } from 'lodash/fp';
 
 jest.mock('@ghostfolio/api/app/portfolio/current-rate.service', () => {
   return {


### PR DESCRIPTION
Test - `apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell.spec.ts`

Používa last metódu z lodash importovanú takto:

`import { last } from 'lodash';`

Output z testu:

```bash
 PASS   api  apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell.spec.ts
  PortfolioCalculator
    get current positions
      ✓ with BALN.SW buy and sell (22 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        **1.932 s**
```

Pri zmene importu z `fp` modulu knižnice lodash vieme skrátiť tento test:

`import { last } from 'lodash/fp';` 

Output z upraveného testu:

```bash
 PASS   api  apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell.spec.ts
  PortfolioCalculator
    get current positions
      ✓ with BALN.SW buy and sell (23 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        **1.198 s**, estimated 2 s
```

**Ušetrili sme 0,734s pri jednom teste, čo je takmer 40%.**

Reasoning:

import { last } from 'lodash' imports the entire Lodash library first, then extracts the last function

- import { last } from 'lodash' imports the entire Lodash library first, then extracts the last function
- import { last } from 'lodash/fp' directly imports only the functional programming version of last

The FP (functional programming) modules in Lodash are modular and can be imported individually. When you import from the main lodash package, you're pulling in the entire library's code base (~70KB minified), even though you only need one function.